### PR TITLE
Sharpen messaging: pain-point hero, PromptOps Why section, badge + ve…

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -256,6 +256,15 @@ a:hover {
     padding: 3rem 20px 2rem;
 }
 
+.hero-kicker {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #2563eb;
+    letter-spacing: 0.01em;
+    margin-bottom: 1rem;
+    text-transform: none;
+}
+
 .home-hero h1 {
     font-size: 2.4rem;
     color: #1f2937;
@@ -667,6 +676,12 @@ a:hover {
 }
 
 .install-section h2 {
+    margin-bottom: 0.5rem;
+}
+
+.install-note {
+    font-size: 0.9rem;
+    color: #6b7280;
     margin-bottom: 1rem;
 }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -136,9 +136,11 @@ description: "See PromptOps and ReleaseOps in action — prompt versioning, bund
             <div class="act-label">Act 4 &mdash; Analytics</div>
             <h3>Behavioral Analytics</h3>
             <p>
-                Aggregate metrics across traces: latency percentiles, token usage,
-                tool call distribution, and error rates. Compare versions with
-                significance thresholds to quantify the behavioral shift.
+                The real story isn't in latency &mdash; it's in what the agent
+                <em>does</em>. Approval rate goes from 20% to 40%, escalation drops
+                from 60% to 40%, while latency and tokens stay flat. Analytics
+                surfaces that behavioral shift so you can decide whether it's
+                the outcome you wanted.
             </p>
         </div>
     </div>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -7,8 +7,9 @@ description: "Get up and running with PromptOps and ReleaseOps in 5 minutes"
 <div class="docs-hero">
     <h1>Getting Started</h1>
     <p class="docs-subtitle">
-        Version your prompts with PromptOps, then bundle and ship them with ReleaseOps.
-        Both tools work standalone or together.
+        By the end of this guide you'll have a versioned prompt, an immutable bundle
+        pinned with policies and model config, and a promotion path through
+        dev &rarr; staging &rarr; prod with eval gates. Both tools work standalone or together.
     </p>
     <div class="docs-badges">
         <span class="docs-badge python">Python 3.8+</span>

--- a/index.html
+++ b/index.html
@@ -6,10 +6,13 @@ description: "Prompt versioning and release engineering for AI agents. Git-nativ
 
 <!-- Hero -->
 <div class="home-hero">
-    <h1>Prompt versioning and release engineering for AI agents</h1>
+    <p class="hero-kicker">Changed a prompt. Agent behaved differently in production. Which line?</p>
+    <h1>Version, bundle, and ship AI agent behavior like software.</h1>
     <p class="lead">
-        Change a prompt. Version it. Bundle it with policies and model config.
-        Ship it through gated environments. Know exactly why behavior changed.
+        Prompts, policies, and model config define your agent &mdash; but most teams deploy them
+        without versioning, testing, or rollback. PromptOps versions every prompt automatically.
+        ReleaseOps bundles them with policies, promotes through gated environments, and traces
+        exactly why behavior changed.
     </p>
     <div class="hero-buttons">
         <a href="/demo/" class="btn btn-lg">See the Demo</a>
@@ -212,7 +215,8 @@ policies = bundle.policies                 <span class="cm"># tool access rules<
 
 <!-- Install -->
 <div class="install-section">
-    <h2>Get started</h2>
+    <h2>Get started in seconds</h2>
+    <p class="install-note">Install both, or start with either &mdash; they work standalone or together.</p>
     <pre><code>pip install llmhq-promptops llmhq-releaseops</code></pre>
 </div>
 

--- a/tools/promptops.html
+++ b/tools/promptops.html
@@ -1,17 +1,34 @@
 ---
 layout: docs
 title: "PromptOps"
-description: "Git-native prompt management and testing framework for production LLM workflows"
+description: "Git-native prompt versioning for production LLM agents. Auto-version prompts on every commit, test any version by name, no manual tagging."
 ---
 
 <div class="docs-hero">
     <h1>PromptOps</h1>
-    <p class="docs-subtitle">Git-native prompt management and testing framework for production LLM workflows</p>
+    <p class="docs-subtitle">Git-native prompt versioning for production LLM agents</p>
     <div class="docs-badges">
         <span class="docs-badge stable">Stable</span>
-        <span class="docs-badge version">v0.1.1</span>
+        <span class="docs-badge version">v0.1.0</span>
         <span class="docs-badge python">Python 3.8+</span>
     </div>
+</div>
+
+<!-- Why -->
+<div class="docs-section">
+    <h2>Why PromptOps?</h2>
+    <p>
+        Your agent's behavior is defined by prompt text &mdash; but most teams ship prompts as
+        raw strings baked into code, with no version history, no rollback, and no way to test
+        a change before it hits production.
+    </p>
+    <p>
+        PromptOps turns prompts into first-class versioned artifacts. Every <code>git commit</code>
+        auto-tags your prompts with a semantic version. Reference any version in code by name:
+        <code>:latest</code> for production, <code>:v1.2.0</code> for a specific release,
+        or <code>:unstaged</code> to test uncommitted changes without touching anything live.
+        No more "what prompt was running last Tuesday?"
+    </p>
 </div>
 
 <!-- Features -->
@@ -27,12 +44,12 @@ description: "Git-native prompt management and testing framework for production 
             <p>Test prompts instantly with <code>:unstaged</code>, <code>:working</code>, <code>:latest</code> references before committing.</p>
         </div>
         <div class="feature-item">
-            <h3>Version-Aware Testing</h3>
-            <p>Test different prompt versions with comprehensive validation. Compare outputs across versions.</p>
+            <h3>Cross-Version Comparison</h3>
+            <p>Test and compare any two prompt versions side-by-side. Catch behavioral changes before they reach production.</p>
         </div>
         <div class="feature-item">
-            <h3>Git Hook Automation</h3>
-            <p>Pre-commit and post-commit hooks for seamless developer workflow. No manual versioning steps.</p>
+            <h3>Zero-Config Git Hooks</h3>
+            <p>Pre-commit and post-commit hooks installed automatically. Versioning happens on every commit &mdash; nothing to remember.</p>
         </div>
     </div>
 </div>

--- a/tools/releaseops.html
+++ b/tools/releaseops.html
@@ -8,7 +8,7 @@ description: "Release engineering infrastructure for AI agent behavior — bundl
     <h1>ReleaseOps</h1>
     <p class="docs-subtitle">Release engineering for AI agent behavior &mdash; bundle, promote, evaluate, and observe behavior artifacts</p>
     <div class="docs-badges">
-        <span class="docs-badge alpha">Alpha</span>
+        <span class="docs-badge stable">Early Access</span>
         <span class="docs-badge version">v0.1.0</span>
         <span class="docs-badge python">Python 3.10+</span>
     </div>


### PR DESCRIPTION
…rsion fixes

- index.html: Add pain-point kicker above h1 ("Changed a prompt. Agent behaved differently. Which line?"), rewrite h1 to be action-oriented, add install section framing line
- tools/promptops.html: Add "Why PromptOps?" section with problem framing, fix version v0.1.1→v0.1.0, fix description (drop "testing framework"), sharpen feature card copy
- tools/releaseops.html: Change "Alpha" badge to "Early Access"
- docs/getting-started.html: Add "by the end of this guide" outcome statement
- demo/index.html: Reframe Act 4 card to lead with behavioral distribution shift, not latency metrics
- assets/css/main.css: Add .hero-kicker and .install-note styles