### PR TITLE
Update for PromptOps v0.6.0, and fix seven statements that were factually wrong

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1,17 +1,19 @@
 - name: PromptOps
   id: promptops
-  description: "Git-native prompt management and testing framework"
+  description: "Git blame for prompts: incident archaeology, git-native versioning, and a no-SaaS production runtime"
   status: "stable"
-  version: "0.1.1"
+  version: "0.6.0"
   pypi: "https://pypi.org/project/llmhq-promptops/"
   github: "https://github.com/llmhq-hub/promptops"
   docs: "/tools/promptops"
   tags: ["prompts", "versioning", "testing", "git"]
   features:
-    - "Automated semantic versioning"
-    - "Uncommitted change testing"
-    - "Framework-agnostic design"
-    - "Version-aware testing"
+    - "Incident archaeology: blame --at answers what was live when it broke"
+    - "Production runtime with no .git/, no git binary, no SaaS"
+    - "Semver impact graded from the variable signature, never prose"
+    - "One-command health check with promptops doctor"
+    - "Version and deploy history in one timeline"
+    - "Structured PROMPTOPS_E0XX errors with hints and doc links"
 
 - name: ReleaseOps
   id: releaseops

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -11,7 +11,7 @@ description: "Get up and running with PromptOps and ReleaseOps in 5 minutes"
         Both tools work standalone or together.
     </p>
     <div class="docs-badges">
-        <span class="docs-badge python">Python 3.8+</span>
+        <span class="docs-badge python">Python 3.10+</span>
         <span class="docs-badge version">Git required</span>
     </div>
 </div>
@@ -43,19 +43,21 @@ pip install llmhq-releaseops    <span class="c"># bundles, promotion, attributio
         <div class="step-marker">1</div>
         <div class="step-body">
             <h3>Initialize a repository</h3>
-            <p>Set up PromptOps in a new or existing git repo. This creates <code>.promptops/</code> with prompt storage and git hooks.</p>
+            <p>Set up PromptOps in a new or existing git repo. This creates <code>.promptops/</code> with prompt storage and a default config. It does <strong>not</strong> touch <code>.git/hooks/</code>: auto-versioning has been a deliberate second step since v0.4.0.</p>
             <div class="dark-code">
                 <div class="code-bar">
                     <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
                     <span class="fname">terminal</span>
                     <span class="lang-tag">bash</span>
                 </div>
-                <pre><code><span class="c"># New project</span>
+                <pre><code><span class="c"># New or existing git repo: creates .promptops/, leaves .git/hooks/ alone</span>
 promptops init repo
 
-<span class="c"># Existing git repo</span>
-<span class="k">cd</span> your-project
-promptops init</code></pre>
+<span class="c"># Opt in to auto-versioning on commit</span>
+promptops hooks install
+
+<span class="c"># Confirm the setup is sane, including that the hooks can actually run</span>
+promptops doctor</code></pre>
             </div>
         </div>
     </div>
@@ -126,7 +128,7 @@ prompt = get_prompt(<span class="s">"welcome-message:unstaged"</span>)</code></p
                     <span class="lang-tag">bash</span>
                 </div>
                 <pre><code><span class="c"># CLI testing</span>
-promptops test --prompt welcome-message:unstaged
+promptops test runtest --prompt welcome-message:unstaged
 promptops test status</code></pre>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ description: "Prompt versioning and release engineering for AI agents. Git-nativ
         <div class="pipeline-step promptops">
             <div class="pipeline-icon">2</div>
             <div class="step-label">Version</div>
-            <div class="step-desc">Git commit auto-tags v1.2.0</div>
+            <div class="step-desc">Commit bumps v1.2.0 &rarr; v2.0.0, graded from the variable signature</div>
         </div>
         <div class="pipeline-step releaseops">
             <div class="pipeline-icon">3</div>
@@ -68,10 +68,11 @@ description: "Prompt versioning and release engineering for AI agents. Git-nativ
             <span class="tool-badge promptops">PromptOps</span>
             <h3>Version your prompts</h3>
             <p>
-                Write prompts as YAML templates with variables.
-                PromptOps auto-versions them on every git commit &mdash;
-                semantic tags, diff tracking, and version history
-                out of the box.
+                Write prompts as YAML templates with variables. Opt in to the
+                git hooks once and every commit grades the change and bumps the
+                version: adding a required variable is MAJOR, rewording is PATCH.
+                The same grader runs in <code>promptops test diff</code>, so review
+                and commit cannot disagree.
             </p>
             <p>
                 Reference any version in code: <code>:v1.2.0</code>,

--- a/tools/index.html
+++ b/tools/index.html
@@ -54,7 +54,7 @@ description: "Production-ready tools for LLM workflows"
         </div>
         <pre><code><span class="c"># 1. PromptOps versions your prompts</span>
 promptops create prompt support-system
-<span class="k">git commit</span> <span class="c"># → auto-tags v1.0.0</span>
+<span class="k">git commit</span> <span class="c"># → tags prompt-welcome-v1.0.0 (after hooks install)</span>
 
 <span class="c"># 2. ReleaseOps bundles and ships them</span>
 releaseops bundle create support-agent \

--- a/tools/promptops.html
+++ b/tools/promptops.html
@@ -1,17 +1,28 @@
 ---
 layout: docs
 title: "PromptOps"
-description: "Git-native prompt management and testing framework for production LLM workflows"
+description: "Git blame for prompts: incident archaeology, git-native versioning, and a no-SaaS production runtime for LLM workflows"
 ---
 
 <div class="docs-hero">
     <h1>PromptOps</h1>
-    <p class="docs-subtitle">Git-native prompt management and testing framework for production LLM workflows</p>
+    <p class="docs-subtitle">Git blame for prompts. Find out which prompt caused the incident, in minutes rather than an afternoon.</p>
     <div class="docs-badges">
         <span class="docs-badge stable">Stable</span>
-        <span class="docs-badge version">v0.1.1</span>
-        <span class="docs-badge python">Python 3.8+</span>
+        <span class="docs-badge version">v0.6.0</span>
+        <span class="docs-badge python">Python 3.10+</span>
     </div>
+</div>
+
+<!-- Why -->
+<div class="docs-section">
+    <h2>Why PromptOps?</h2>
+    <p>Your agent did something wrong in production last Tuesday. Which prompt was live
+    at the time? What did it say before someone edited it? Which deploy shipped it?</p>
+    <p>If your prompts are string literals in code, or rows in a SaaS dashboard, those
+    questions take an afternoon. PromptOps keeps prompts as YAML in your own git repo, so
+    they get the same version history, blame, and diff every other artifact in your stack
+    already has. No database, no vendor, no lock-in.</p>
 </div>
 
 <!-- Features -->
@@ -19,20 +30,28 @@ description: "Git-native prompt management and testing framework for production 
     <h2>Features</h2>
     <div class="feature-grid-docs">
         <div class="feature-item">
-            <h3>Automated Git Versioning</h3>
-            <p>Zero-manual versioning with git hooks and semantic version detection. Every commit auto-tags your prompts.</p>
+            <h3>Incident archaeology</h3>
+            <p><code>promptops blame --at &lt;timestamp&gt;</code> answers "what text was this prompt when the incident happened", from the deploy log and git history.</p>
         </div>
         <div class="feature-item">
-            <h3>Uncommitted Change Testing</h3>
-            <p>Test prompts instantly with <code>:unstaged</code>, <code>:working</code>, <code>:latest</code> references before committing.</p>
+            <h3>Production runtime, no SaaS</h3>
+            <p>Ship one <code>snapshot.json</code> in your image. No <code>.git/</code> directory and no git binary needed at runtime.</p>
         </div>
         <div class="feature-item">
-            <h3>Version-Aware Testing</h3>
-            <p>Test different prompt versions with comprehensive validation. Compare outputs across versions.</p>
+            <h3>Semver impact on every change</h3>
+            <p><code>promptops test diff</code> grades a change MAJOR, MINOR or PATCH from the variable signature, so a breaking change cannot slip through review.</p>
         </div>
         <div class="feature-item">
-            <h3>Git Hook Automation</h3>
-            <p>Pre-commit and post-commit hooks for seamless developer workflow. No manual versioning steps.</p>
+            <h3>Version and deploy history</h3>
+            <p><code>promptops history</code> shows every version a prompt has been, and which deploys actually shipped each one.</p>
+        </div>
+        <div class="feature-item">
+            <h3>One-command health check</h3>
+            <p><code>promptops doctor</code> checks structure, hooks, snapshot freshness, deploy-log health, versions and resolver mode.</p>
+        </div>
+        <div class="feature-item">
+            <h3>Opt-in git hooks</h3>
+            <p>Auto-version prompts on commit when you want it, graded by the same engine as <code>test diff</code>. <code>init</code> never writes to <code>.git/hooks/</code> unless you ask.</p>
         </div>
     </div>
 </div>
@@ -59,18 +78,268 @@ description: "Git-native prompt management and testing framework for production 
             <span class="fname">terminal</span>
             <span class="lang-tag">bash</span>
         </div>
-        <pre><code><span class="c"># Create a new project with git hooks</span>
+        <pre><code><span class="c"># Create .promptops/ in your repo. Does NOT touch .git/hooks/.</span>
 promptops init repo
 
-<span class="c"># Create a new prompt template</span>
+<span class="c"># Opt in to auto-versioning on commit (a deliberate second step)</span>
+promptops hooks install
+
+<span class="c"># Scaffold a prompt template</span>
 promptops create prompt welcome-message
 
-<span class="c"># Test uncommitted changes</span>
-promptops test --prompt welcome-message:unstaged
+<span class="c"># Test uncommitted changes before you commit them</span>
+promptops test runtest --prompt welcome-message:unstaged
 
-<span class="c"># Check status of all prompts</span>
+<span class="c"># Status of every prompt</span>
 promptops test status</code></pre>
     </div>
+    <p>Hooks have been opt-in since v0.4.0. <code>init repo</code> creates the directory
+    tree and a default config, and never writes into <code>.git/hooks/</code> unless you
+    run <code>hooks install</code> (or pass <code>--with-hooks</code>).</p>
+</div>
+
+<!-- Incident archaeology -->
+<div class="docs-section">
+    <h2>Incident archaeology</h2>
+    <p>The flow PromptOps exists for. Record what you ship, then ask what was live when
+    something broke.</p>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">terminal</span>
+            <span class="lang-tag">bash</span>
+        </div>
+        <pre><code><span class="c"># In CI, after you deploy</span>
+promptops deploy event --env prod
+
+<span class="c"># Later, during an incident</span>
+promptops blame --at <span class="s">"2026-05-20T14:32:00Z"</span> --prompt refund-policy</code></pre>
+    </div>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">output</span>
+            <span class="lang-tag">text</span>
+        </div>
+        <pre><code>Blame: env=prod, at=2026-05-20T14:32:00+00:00
+
+Deploy event:
+  timestamp:   2026-05-20T14:20:58+00:00
+  commit:      47d71643d7fe (47d71643d7fe9b4ef6e9391f8bb6d8c8b65150e2)
+  deployed_by: ci
+  metadata:    (none)
+
+Resolved prompt 'refund-policy' (source=git):
+  version: v1.2.0
+  commit:  47d71643d7fe9b4ef6e9391f8bb6d8c8b65150e2
+  text:
+    metadata:
+      id: refund-policy
+      description: Refund decision policy
+    template: |
+      Approve refunds under {% raw %}{{ threshold }}{% endraw %} automatically.
+      Escalate anything above to a human reviewer.</code></pre>
+    </div>
+    <p>You now have the exact text that produced the behavior, and the commit it came
+    from. Timestamps accept ISO 8601, a bare date, or the literal <code>now</code>.
+    Drop <code>--prompt</code> to see every prompt at that deploy.</p>
+    <p>Then ask when it changed:</p>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">terminal</span>
+            <span class="lang-tag">bash</span>
+        </div>
+        <pre><code>promptops history refund-policy</code></pre>
+    </div>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">output</span>
+            <span class="lang-tag">text</span>
+        </div>
+        <pre><code>&#128220; History for refund-policy
+============================================================
+  v1.2.0           47d71643  2026-05-20  Dev
+      fix: escalate large refunds
+      &#9492;&#9472; deployed to prod at 2026-05-20T14:20:58+00:00 by ci
+
+  v1.1.0           276fcb9a  2026-05-01  Dev
+      feat: refund policy
+      &#9492;&#9472; deployed to prod at 2026-05-01T09:30:00+00:00 by ci</code></pre>
+    </div>
+    <p>Deploy markers attach to the version that was <strong>live</strong> at that
+    moment, not to whichever commit the deploy event happens to name. A deploy records
+    the repository commit, which usually is not the commit that last touched this
+    prompt.</p>
+</div>
+
+<!-- Production runtime -->
+<div class="docs-section">
+    <h2>Production runtime without git</h2>
+    <p>Build a snapshot in CI, ship that one file, and resolve from it at runtime. The
+    production image needs no <code>.git/</code> directory and, since v0.5.0, no git
+    binary either.</p>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">Dockerfile</span>
+            <span class="lang-tag">docker</span>
+        </div>
+        <pre><code><span class="c"># In CI, before building:  promptops snapshot build</span>
+<span class="k">FROM</span> python:3.11-slim
+<span class="k">WORKDIR</span> /app
+
+<span class="k">RUN</span> pip install --no-cache-dir <span class="s">'llmhq-promptops&gt;=0.6.0'</span>
+
+<span class="c"># The only PromptOps artifact. No .git/, no prompt YAML.</span>
+<span class="k">COPY</span> snapshot.json /app/.promptops/snapshot.json
+<span class="k">COPY</span> app.py /app/</code></pre>
+    </div>
+    <p><code>python:3.11-slim</code> ships no git binary. Before v0.5.0 that made
+    <code>import llmhq_promptops</code> fail outright; it now works, and
+    <code>promptops doctor</code> runs cleanly in such an image. The distinction matters:
+    the SDK's snapshot path needs neither the <code>.git/</code> directory nor the git
+    executable, while the CLI still needs git for any git-backed command.</p>
+</div>
+
+<!-- Impact / CI -->
+<div class="docs-section">
+    <h2>Catch breaking changes at review</h2>
+    <p>A prompt's variable interface is its contract with callers. PromptOps grades every
+    change against it, and deliberately never grades prose: a rule that guessed at intent
+    would produce annotations nobody trusts.</p>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">terminal</span>
+            <span class="lang-tag">bash</span>
+        </div>
+        <pre><code>promptops test diff refund-policy</code></pre>
+    </div>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">output</span>
+            <span class="lang-tag">text</span>
+        </div>
+        <pre><code>IMPACT: MAJOR
+  MAJOR required variable 'account_tier' added
+
+--- working
++++ unstaged
+@@ -12,3 +12,6 @@
+   user_input:
+     type: string
+     required: true
++  account_tier:</code></pre>
+    </div>
+    <p>Add <code>--exit-code</code> to gate CI on the verdict, or <code>--json</code> for
+    tooling.</p>
+    <table class="extras-table">
+        <tr><th>Exit code</th><th>Meaning</th></tr>
+        <tr><td>0</td><td>NONE or PATCH</td></tr>
+        <tr><td>1</td><td>the command failed</td></tr>
+        <tr><td>2</td><td>MINOR</td></tr>
+        <tr><td>3</td><td>MAJOR</td></tr>
+    </table>
+    <p>This borrows git's <code>--exit-code</code> flag but not git's numbers.
+    <code>git diff</code> uses <code>1</code> for "differences found", while PromptOps
+    reserves <code>1</code> for "the command failed" because there are three severities
+    to encode. Without the flag the command still exits 0, and prints a note telling you
+    the flag exists so a forgotten flag cannot silently pass a breaking change.</p>
+    <p>Ready-made CI wiring ships in the repo: a
+    <a href="https://github.com/llmhq-hub/promptops/blob/main/examples/github-actions/promptops-diff.yml">GitHub Actions workflow</a>
+    that posts prompt impact as a sticky PR comment, and
+    <a href="https://github.com/llmhq-hub/promptops/blob/main/.pre-commit-hooks.yaml"><code>.pre-commit-hooks.yaml</code></a>
+    for teams already standardized on pre-commit.</p>
+</div>
+
+<!-- Automated versioning -->
+<div class="docs-section">
+    <h2>Versions that bump themselves</h2>
+    <p>With <code>promptops hooks install</code> done once, committing a prompt grades
+    the change and writes the new version into the file. It is the
+    <em>same grader</em> as <code>test diff</code> above, so a change your CI blocks as
+    breaking cannot be stamped with a minor version.</p>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">terminal</span>
+            <span class="lang-tag">bash</span>
+        </div>
+        <pre><code>git commit -m <span class="s">"feat: tier-aware refund policy"</span></code></pre>
+    </div>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">output</span>
+            <span class="lang-tag">text</span>
+        </div>
+        <pre><code>[promptops] 📊 Change analysis for .promptops/prompts/refund-policy.yaml:
+[promptops]    Impact: MAJOR
+[promptops]    Version: v1.2.0 → v2.0.0
+[promptops]    • required variable 'account_tier' added
+[promptops] ✅ Updated version to v2.0.0
+[promptops] 🏷️  Created tag: prompt-refund-policy-v2.0.0</code></pre>
+    </div>
+    <p>Impact comes from the prompt's <strong>variable signature</strong> and declared
+    models. Prose is never graded, because the variable interface is the only part of a
+    prompt with a caller-facing contract, and a rule that guessed at intent would produce
+    annotations nobody trusts.</p>
+    <table class="extras-table">
+        <tr><th>Change</th><th>Version</th></tr>
+        <tr><td>Required variable added, removed, renamed, or retyped</td><td>MAJOR &nbsp;1.2.0 → 2.0.0</td></tr>
+        <tr><td>Optional variable promoted to required</td><td>MAJOR</td></tr>
+        <tr><td>Declared model removed</td><td>MAJOR</td></tr>
+        <tr><td>Optional variable added or removed</td><td>MINOR &nbsp;1.2.0 → 1.3.0</td></tr>
+        <tr><td>Required variable relaxed to optional</td><td>MINOR</td></tr>
+        <tr><td>Model added, or an optional default changed</td><td>MINOR</td></tr>
+        <tr><td>Prose changed, signature identical</td><td>PATCH &nbsp;1.2.0 → 1.2.1</td></tr>
+        <tr><td>Nothing a caller depends on moved</td><td>no bump</td></tr>
+    </table>
+    <p>A brand-new prompt keeps the version you declared: there is nothing for a first
+    commit to be backward incompatible with.</p>
+    <p>The bump rewrites the version line and <em>nothing else</em>, so comments and
+    <code>template: |</code> formatting survive intact:</p>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">.promptops/prompts/refund-policy.yaml</span>
+            <span class="lang-tag">yaml</span>
+        </div>
+        <pre><code><span class="c"># Owned by the billing team. Ping #billing before changing the wording.</span>
+metadata:
+  id: refund-policy
+  version: v2.0.0
+template: |
+  Explain the refund policy to {% raw %}{{ user_name }}{% endraw %} on the {% raw %}{{ account_tier }}{% endraw %} plan.</code></pre>
+    </div>
+    <p>Tags are written as <code>prompt-&lt;id&gt;-v&lt;version&gt;</code>, which is the
+    format <code>promptops history</code> and <code>promptops blame</code> read, so every
+    version the hook creates is visible to the rest of the tool.</p>
+    <p><strong>Upgrading?</strong> Hooks were broken from v0.2.0 through v0.5.0 and are
+    repaired in v0.6.0. If you installed them on an earlier release and versioning never
+    seemed to fire, that is why. See
+    <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/migration-v0.5-to-v0.6.md">upgrading to v0.6.0</a>.</p>
+</div>
+
+<!-- Health -->
+<div class="docs-section">
+    <h2>Is this setup sane?</h2>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">terminal</span>
+            <span class="lang-tag">bash</span>
+        </div>
+        <pre><code>promptops doctor</code></pre>
+    </div>
+    <p>Six checks in one command: <code>.promptops/</code> structure and config parse,
+    hook installation, snapshot freshness against HEAD, deploy-log health including
+    malformed lines, prompts with no committed version, and which backend the resolver
+    will pick here. Exits 0 when every check is OK or a warning, and 1 when any fails, so
+    warnings never break CI. Add <code>--json</code> for machine output.</p>
 </div>
 
 <!-- Python SDK -->
@@ -84,7 +353,7 @@ promptops test status</code></pre>
         </div>
         <pre><code><span class="k">from</span> <span class="f">llmhq_promptops</span> <span class="k">import</span> get_prompt
 
-<span class="c"># Smart default (unstaged if different, else working)</span>
+<span class="c"># Smart default: snapshot in production, git in development</span>
 prompt = get_prompt(<span class="s">"user-onboarding"</span>)
 
 <span class="c"># Specific version references</span>
@@ -98,6 +367,10 @@ rendered = get_prompt(<span class="s">"user-onboarding"</span>, {
     <span class="s">"plan"</span>: <span class="s">"Pro"</span>
 })</code></pre>
     </div>
+    <p>Failures raise <code>PromptOpsError</code> with a stable
+    <code>PROMPTOPS_E0XX</code> code, a hint, and a link to the fix. Branch on
+    <code>e.code</code> rather than parsing messages. Every code is documented in the
+    <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/error-codes.md">error-code reference</a>.</p>
 </div>
 
 <!-- Framework Integration -->
@@ -137,11 +410,25 @@ response = client.messages.<span class="f">create</span>(
 <!-- Requirements -->
 <div class="docs-section">
     <h2>Requirements</h2>
-    <ul class="req-list">
-        <li>Python 3.8+</li>
-        <li>Git (required for versioning)</li>
-        <li>Dependencies: Typer, Jinja2, PyYAML, GitPython</li>
-    </ul>
+    <table class="extras-table">
+        <tr><th>Requirement</th><th>Detail</th></tr>
+        <tr><td>Python</td><td>3.10 or newer</td></tr>
+        <tr><td>Git</td><td>Needed for the CLI's git-backed commands. The SDK's snapshot path needs neither the <code>.git/</code> directory nor the git binary.</td></tr>
+        <tr><td>Dependencies</td><td>Typer, Click, Jinja2, PyYAML, GitPython</td></tr>
+    </table>
+</div>
+
+<!-- Guides -->
+<div class="docs-section">
+    <h2>Guides</h2>
+    <div class="link-cards">
+        <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/day-0-playbook.md" class="link-card">Day 0 Incident Playbook</a>
+        <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/production-deployment.md" class="link-card">Production Deployment</a>
+        <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/migration-from-hardcoded-prompts.md" class="link-card">Migrating from Hardcoded Prompts</a>
+        <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/error-codes.md" class="link-card">Error Codes</a>
+        <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/migration-v0.5-to-v0.6.md" class="link-card">Upgrading to v0.6.0</a>
+        <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/migration-v0.4-to-v0.5.md" class="link-card">Upgrading to v0.5.0</a>
+    </div>
 </div>
 
 <!-- Links -->


### PR DESCRIPTION
The site described PromptOps as it existed at **v0.1.1**, five releases back.
Seven statements were not merely stale: following them produced an error or a
silent no-op.

**Merging this publishes it.** This repo has no Actions workflow, so `main` is
production and there is no staging step.

## Wrong, and now fixed

| Where | Said | Reality |
|---|---|---|
| badge, `_data/tools.yml` | `v0.1.1` | PyPI is at `0.6.0` |
| promptops page, getting-started | `promptops test --prompt ...` | `Error: No such option: --prompt`. `test` is a sub-app; the flag is on `runtest` |
| getting-started | `promptops init` for an existing repo | `Error: Missing command` |
| getting-started badge | `Python 3.8+` | `requires-python >= 3.10` since v0.4.0, so 3.8 gets a pip resolution failure |
| 4 places | "auto-tags", "auto-versions on every git commit", "creates ... and git hooks" | Hooks are opt-in since v0.4.0; `init repo` never touches `.git/hooks/` |

The hooks one was the worst, because the failure is **silent**. You follow the
site, commit, and versioning simply never fires. Nothing errors. Every one of
those places now shows `promptops hooks install` as the deliberate second step.

## Why now, and not just a version bump

The promptops page gains a **"Versions that bump themselves"** section with the
real grading table.

As of v0.6.0 the git hook and `promptops test diff` share one grader. Before
v0.6.0 they disagreed: adding a required variable was MINOR to the hook and
MAJOR to `test diff`, so CI blocked a PR as breaking while the hook stamped a
non-breaking version on the same commit. Publishing the old rules after that
release would have told people a breaking change was safe.

The section also documents that the bump rewrites the version line and nothing
else (comments and `template: |` formatting survive), that tags are written as
`prompt-<id>-v<version>` so `history` and `blame` can see them, and carries an
upgrade note that hooks were broken from v0.2.0 through v0.5.0.

`_data/tools.yml` moves from the v0.1.x feature list to the current product:
incident archaeology, the runtime that needs no `.git/` and no git binary,
`doctor`, `history`, structured `PROMPTOPS_E0XX` errors.

## Verified, not assumed

- **All 13 commands** on the changed pages were executed against
  `llmhq-promptops 0.6.0` installed from PyPI into a clean venv. All 13 exit 0.
  That standard is what caught the bare `promptops init` bug, which had been
  live for five releases.
- The hook output and the YAML in the new section are **byte-exact output from
  a real commit**, not written from memory.
- `jekyll build` exits 0, no errors or warnings. The **rendered** HTML was
  checked, not just the source: `{{ user_name }}` survives (Liquid eats `{{ }}`
  without `{% raw %}`), the badge reads v0.6.0, and no stale claim survives in
  `_site/`.
- Every CSS class on the page resolves against `assets/css/main.css`. An
  earlier draft used `.req-list`, which does not exist.

## Not in this PR

`origin/site/comprehensive-coverage` (+4333/-675, six demo pages, a design
refresh) stays parked. It is orthogonal to content accuracy and would carry
several of the above errors forward, plus a `promptops list` command that does
not exist. If it lands later, these fixes must be reapplied to the files it
rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)