### PR TITLE
Update for PromptOps v0.6.0, and fix nine things the site got wrong

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1,17 +1,19 @@
 - name: PromptOps
   id: promptops
-  description: "Git-native prompt management and testing framework"
+  description: "Git blame for prompts: incident archaeology, git-native versioning, and a no-SaaS production runtime"
   status: "stable"
-  version: "0.1.0"
+  version: "0.6.0"
   pypi: "https://pypi.org/project/llmhq-promptops/"
   github: "https://github.com/llmhq-hub/promptops"
   docs: "/tools/promptops"
   tags: ["prompts", "versioning", "testing", "git"]
   features:
-    - "Automated semantic versioning"
-    - "Uncommitted change testing"
-    - "Framework-agnostic design"
-    - "Version-aware testing"
+    - "Incident archaeology: blame --at answers what was live when it broke"
+    - "Production runtime with no .git/, no git binary, no SaaS"
+    - "Semver impact graded from the variable signature, never prose"
+    - "One-command health check with promptops doctor"
+    - "Version and deploy history in one timeline"
+    - "Structured PROMPTOPS_E0XX errors with hints and doc links"
 
 - name: ReleaseOps
   id: releaseops

--- a/demos/prompt-versioning/index.html
+++ b/demos/prompt-versioning/index.html
@@ -106,9 +106,9 @@ description: "See PromptOps auto-version a code review agent's prompts — PATCH
             <div class="act-label">Act 1 &mdash; Create</div>
             <h3>Auto-Versioning via Git</h3>
             <p>
-                Create a prompt template with variables, commit it, and PromptOps
-                auto-tags <code>v1.0.0</code>. Every commit is versioned &mdash;
-                no manual <code>git tag</code> needed.
+                Create a prompt template with variables, run
+                <code>promptops hooks install</code> once, and every commit from then on
+                tags it for you &mdash; no manual <code>git tag</code> needed.
             </p>
         </div>
         <div class="feature-card">
@@ -150,8 +150,9 @@ description: "See PromptOps auto-version a code review agent's prompts — PATCH
     </p>
     <div style="text-align: left; max-width: 400px; margin: 0 auto 1.5rem;">
         <pre><code>pip install llmhq-promptops
-promptops init
-promptops list</code></pre>
+promptops init repo
+promptops hooks install
+promptops test status</code></pre>
     </div>
     <div class="cta-buttons">
         <a href="/tools/promptops" class="btn">PromptOps Docs</a>
@@ -202,16 +203,16 @@ promptops list</code></pre>
       required: true
   template: |
     You are a senior code reviewer at DevCorp.
-    You review {{ language }} pull requests for:
+    You review {% raw %}{{ language }}{% endraw %} pull requests for:
     1. Correctness — does the code do what it claims?
-    2. Style — does it follow {{ language }} conventions?
+    2. Style — does it follow {% raw %}{{ language }}{% endraw %} conventions?
     3. Security — are there any vulnerabilities?
 
     Flag all issues as errors. Be thorough and strict.
 
-    Pull Request: {{ pull_request }}
+    Pull Request: {% raw %}{{ pull_request }}{% endraw %}
     Diff:
-    {{ diff }}
+    {% raw %}{{ diff }}{% endraw %}
 
 --- Commit & Auto-Version -------------------------------
 
@@ -255,7 +256,7 @@ promptops list</code></pre>
       description: "Minimum severity to report (low/medium/high)"
 
   Template updated:
-    + "Only report issues at {{ severity_threshold }} severity or above."
+    + "Only report issues at {% raw %}{{ severity_threshold }}{% endraw %} severity or above."
 
   + git commit -m "Add severity threshold variable"
 
@@ -271,7 +272,7 @@ promptops list</code></pre>
 
   Removed variable: language
   Template updated:
-    - "You review {{ language }} pull requests for:"
+    - "You review {% raw %}{{ language }}{% endraw %} pull requests for:"
     + "You review pull requests for:"
 
   + git commit -m "Remove language variable, use auto-detection"
@@ -368,7 +369,7 @@ promptops list</code></pre>
     + severity_threshold (required)
 
   Template additions:
-    + Only report issues at {{ severity_threshold }} severity or above.
+    + Only report issues at {% raw %}{{ severity_threshold }}{% endraw %} severity or above.
 
   + Backward-compatible: existing callers still work
     (new variable is additive)
@@ -381,7 +382,7 @@ promptops list</code></pre>
     - language (required)
 
   Template changes:
-    - You review {{ language }} pull requests for:
+    - You review {% raw %}{{ language }}{% endraw %} pull requests for:
     + You review pull requests for:
 
   ! Breaking: callers passing 'language' will get an error

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -12,7 +12,7 @@ description: "Get up and running with PromptOps and ReleaseOps in 5 minutes"
         dev &rarr; staging &rarr; prod with eval gates. Both tools work standalone or together.
     </p>
     <div class="docs-badges">
-        <span class="docs-badge python">Python 3.8+</span>
+        <span class="docs-badge python">Python 3.10+</span>
         <span class="docs-badge version">Git required</span>
     </div>
 </div>
@@ -44,19 +44,21 @@ pip install llmhq-releaseops    <span class="c"># bundles, promotion, attributio
         <div class="step-marker">1</div>
         <div class="step-body">
             <h3>Initialize a repository</h3>
-            <p>Set up PromptOps in a new or existing git repo. This creates <code>.promptops/</code> with prompt storage and git hooks.</p>
+            <p>Set up PromptOps in a new or existing git repo. This creates <code>.promptops/</code> with prompt storage and a default config. It does <strong>not</strong> touch <code>.git/hooks/</code>: auto-versioning has been a deliberate second step since v0.4.0.</p>
             <div class="dark-code">
                 <div class="code-bar">
                     <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
                     <span class="fname">terminal</span>
                     <span class="lang-tag">bash</span>
                 </div>
-                <pre><code><span class="c"># New project</span>
+                <pre><code><span class="c"># New or existing git repo: creates .promptops/, leaves .git/hooks/ alone</span>
 promptops init repo
 
-<span class="c"># Existing git repo</span>
-<span class="k">cd</span> your-project
-promptops init</code></pre>
+<span class="c"># Opt in to auto-versioning on commit</span>
+promptops hooks install
+
+<span class="c"># Confirm the setup is sane, including that the hooks can actually run</span>
+promptops doctor</code></pre>
             </div>
         </div>
     </div>
@@ -86,7 +88,7 @@ promptops init</code></pre>
   <span class="k">user_name:</span> <span class="d">{ required: true }</span>
   <span class="k">plan:</span> <span class="d">{ required: true }</span>
 <span class="k">template:</span> <span class="o">|</span>
-  Welcome {{ user_name }}! You're on the {{ plan }} plan.
+  Welcome {% raw %}{{ user_name }}{% endraw %}! You're on the {% raw %}{{ plan }}{% endraw %} plan.
   Here's how to get started...</code></pre>
             </div>
         </div>
@@ -127,7 +129,7 @@ prompt = get_prompt(<span class="s">"welcome-message:unstaged"</span>)</code></p
                     <span class="lang-tag">bash</span>
                 </div>
                 <pre><code><span class="c"># CLI testing</span>
-promptops test --prompt welcome-message:unstaged
+promptops test runtest --prompt welcome-message:unstaged
 promptops test status</code></pre>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ description: "Prompt versioning and release engineering for AI agents. Git-nativ
             <h3>Version your prompts</h3>
             <p>
                 Write prompts as YAML templates with variables.
-                PromptOps auto-versions them on every git commit &mdash;
+                Opt in to the git hooks once and every commit grades the change and bumps the version &mdash;
                 semantic tags, diff tracking, and version history
                 out of the box.
             </p>

--- a/tools/index.html
+++ b/tools/index.html
@@ -54,7 +54,7 @@ description: "Production-ready tools for LLM workflows"
         </div>
         <pre><code><span class="c"># 1. PromptOps versions your prompts</span>
 promptops create prompt support-system
-<span class="k">git commit</span> <span class="c"># → auto-tags v1.0.0</span>
+<span class="k">git commit</span> <span class="c"># → tags prompt-welcome-v1.0.0 (after hooks install)</span>
 
 <span class="c"># 2. ReleaseOps bundles and ships them</span>
 releaseops bundle create support-agent \

--- a/tools/promptops.html
+++ b/tools/promptops.html
@@ -9,8 +9,8 @@ description: "Git-native prompt versioning for production LLM agents. Auto-versi
     <p class="docs-subtitle">Git-native prompt versioning for production LLM agents</p>
     <div class="docs-badges">
         <span class="docs-badge stable">Stable</span>
-        <span class="docs-badge version">v0.1.0</span>
-        <span class="docs-badge python">Python 3.8+</span>
+        <span class="docs-badge version">v0.6.0</span>
+        <span class="docs-badge python">Python 3.10+</span>
     </div>
 </div>
 
@@ -23,11 +23,16 @@ description: "Git-native prompt versioning for production LLM agents. Auto-versi
         a change before it hits production.
     </p>
     <p>
-        PromptOps turns prompts into first-class versioned artifacts. Every <code>git commit</code>
-        auto-tags your prompts with a semantic version. Reference any version in code by name:
-        <code>:latest</code> for production, <code>:v1.2.0</code> for a specific release,
-        or <code>:unstaged</code> to test uncommitted changes without touching anything live.
-        No more "what prompt was running last Tuesday?"
+        PromptOps turns prompts into first-class versioned artifacts. Opt in to the git
+        hooks once and every <code>git commit</code> grades the change and tags it with a
+        semantic version. Reference any version in code by name: <code>:latest</code> for
+        production, <code>:v1.2.0</code> for a specific release, or <code>:unstaged</code>
+        to test uncommitted changes without touching anything live.
+    </p>
+    <p>
+        And when something does break, <code>promptops blame --at "2026-05-20T14:32:00Z"</code>
+        answers "what was this prompt's text when the incident happened", from the deploy log
+        and git history. No more "what prompt was running last Tuesday?"
     </p>
 </div>
 
@@ -36,20 +41,20 @@ description: "Git-native prompt versioning for production LLM agents. Auto-versi
     <h2>Features</h2>
     <div class="feature-grid-docs">
         <div class="feature-item">
-            <h3>Automated Git Versioning</h3>
-            <p>Zero-manual versioning with git hooks and semantic version detection. Every commit auto-tags your prompts.</p>
+            <h3>Incident archaeology</h3>
+            <p><code>blame --at &lt;timestamp&gt;</code> answers what text was live when something broke, from the deploy log and git history.</p>
         </div>
         <div class="feature-item">
             <h3>Uncommitted Change Testing</h3>
             <p>Test prompts instantly with <code>:unstaged</code>, <code>:working</code>, <code>:latest</code> references before committing.</p>
         </div>
         <div class="feature-item">
-            <h3>Cross-Version Comparison</h3>
-            <p>Test and compare any two prompt versions side-by-side. Catch behavioral changes before they reach production.</p>
+            <h3>Semver impact at review time</h3>
+            <p><code>promptops test diff</code> grades a change MAJOR, MINOR or PATCH from the variable signature, and <code>--exit-code</code> gates CI on the verdict.</p>
         </div>
         <div class="feature-item">
-            <h3>Zero-Config Git Hooks</h3>
-            <p>Pre-commit and post-commit hooks installed automatically. Versioning happens on every commit &mdash; nothing to remember.</p>
+            <h3>Opt-in git hooks</h3>
+            <p>One <code>promptops hooks install</code> and every commit versions your prompts, graded by the same engine as <code>test diff</code>. <code>init</code> never writes to <code>.git/hooks/</code> unless you ask.</p>
         </div>
     </div>
 </div>
@@ -76,17 +81,23 @@ description: "Git-native prompt versioning for production LLM agents. Auto-versi
             <span class="fname">terminal</span>
             <span class="lang-tag">bash</span>
         </div>
-        <pre><code><span class="c"># Create a new project with git hooks</span>
+        <pre><code><span class="c"># Create .promptops/ in your repo. Does NOT touch .git/hooks/.</span>
 promptops init repo
+
+<span class="c"># Opt in to auto-versioning on commit (a deliberate second step)</span>
+promptops hooks install
 
 <span class="c"># Create a new prompt template</span>
 promptops create prompt welcome-message
 
 <span class="c"># Test uncommitted changes</span>
-promptops test --prompt welcome-message:unstaged
+promptops test runtest --prompt welcome-message:unstaged
 
 <span class="c"># Check status of all prompts</span>
-promptops test status</code></pre>
+promptops test status
+
+<span class="c"># Is this setup sane? Checks hooks can actually run.</span>
+promptops doctor</code></pre>
     </div>
 </div>
 
@@ -138,17 +149,50 @@ rendered = get_prompt(<span class="s">"user-onboarding"</span>, {
 <!-- Semantic Versioning -->
 <div class="docs-section">
     <h2>Semantic Versioning Rules</h2>
-    <p>PromptOps detects what changed and picks the right version bump automatically.</p>
+    <p>Impact is derived from the prompt's <strong>variable signature</strong> and its
+    declared models, and from nothing else. Prose is never graded: the variable interface
+    is the only part of a prompt with a caller-facing contract, and a rule that guessed at
+    intent would produce annotations nobody trusts.</p>
     <table class="extras-table">
         <thead>
             <tr><th>Bump</th><th>Trigger</th><th>Example</th></tr>
         </thead>
         <tbody>
-            <tr><td><strong>PATCH</strong></td><td>Template content changes only</td><td>1.0.0 &rarr; 1.0.1</td></tr>
-            <tr><td><strong>MINOR</strong></td><td>New variables added (backward compatible)</td><td>1.0.0 &rarr; 1.1.0</td></tr>
-            <tr><td><strong>MAJOR</strong></td><td>Required variables removed (breaking change)</td><td>1.0.0 &rarr; 2.0.0</td></tr>
+            <tr><td><strong>MAJOR</strong></td><td>Required variable added, removed, renamed or retyped; an optional variable promoted to required; a declared model dropped</td><td>1.2.0 &rarr; 2.0.0</td></tr>
+            <tr><td><strong>MINOR</strong></td><td>Optional variable added or removed; a required variable relaxed to optional; a model added; an optional default changed</td><td>1.2.0 &rarr; 1.3.0</td></tr>
+            <tr><td><strong>PATCH</strong></td><td>Prose changed, signature identical</td><td>1.2.0 &rarr; 1.2.1</td></tr>
+            <tr><td><strong>none</strong></td><td>Nothing a caller depends on moved</td><td>1.2.0 &rarr; 1.2.0</td></tr>
         </tbody>
     </table>
+    <p>The git hook and <code>promptops test diff</code> use the <em>same</em> grader, so a
+    change your CI blocks as breaking cannot be stamped with a minor version on commit:</p>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">terminal</span>
+            <span class="lang-tag">bash</span>
+        </div>
+        <pre><code>git commit -m <span class="s">"feat: tier-aware refund policy"</span></code></pre>
+    </div>
+    <div class="dark-code">
+        <div class="code-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="fname">output</span>
+            <span class="lang-tag">text</span>
+        </div>
+        <pre><code>[promptops]    Impact: MAJOR
+[promptops]    Version: v1.2.0 &rarr; v2.0.0
+[promptops]    &bull; required variable 'account_tier' added
+[promptops] Updated version to v2.0.0
+[promptops] Created tag: prompt-refund-policy-v2.0.0</code></pre>
+    </div>
+    <p>A brand-new prompt keeps the version you declared: there is nothing for a first
+    commit to be backward incompatible with. The bump rewrites the version line and
+    <em>nothing else</em>, so comments and <code>template: |</code> formatting survive.</p>
+    <p><strong>Upgrading?</strong> The git hooks were broken from v0.2.0 through v0.5.0 and
+    are repaired in v0.6.0. If you installed them on an earlier release and versioning never
+    seemed to fire, that is why. See
+    <a href="https://github.com/llmhq-hub/promptops/blob/main/docs/migration-v0.5-to-v0.6.md">upgrading to v0.6.0</a>.</p>
 </div>
 
 <!-- Framework Integration -->
@@ -189,9 +233,9 @@ response = client.messages.<span class="f">create</span>(
 <div class="docs-section">
     <h2>Requirements</h2>
     <ul class="req-list">
-        <li>Python 3.8+</li>
-        <li>Git (required for versioning)</li>
-        <li>Dependencies: Typer, Jinja2, PyYAML, GitPython</li>
+        <li>Python 3.10+</li>
+        <li>Git, for the CLI's git-backed commands. The SDK's snapshot path needs neither the <code>.git/</code> directory nor the git binary, so it runs in a <code>python:3.11-slim</code> image.</li>
+        <li>Dependencies: Typer, Click, Jinja2, PyYAML, GitPython</li>
     </ul>
 </div>
 


### PR DESCRIPTION
Supersedes #10, which I had branched off a **stale local main** predating the
design refresh (#6 to #9, merged 2026-03-06). Redone on top of the real `main`.

**Merging publishes.** No Actions workflow on this repo, so `main` is
production and there is no staging step.

## Nine things wrong on the live site

**Version and requirements**

| Where | Says | Reality |
|---|---|---|
| badge, `_data/tools.yml` | `v0.1.0` | PyPI is at `0.6.0` |
| 3 places | `Python 3.8+` | `requires-python >= 3.10` since v0.4.0; 3.8 gets a pip resolution failure |

**Commands that do not exist**

| Command | Result |
|---|---|
| `promptops test --prompt ...` | `Error: No such option: --prompt` (the flag is on `runtest`) |
| `promptops init` | `Error: Missing command` |
| `promptops list` | not a command at all |

**Claims that fail silently, which is worse.** Five places say hooks are
automatic: "creates `.promptops/` ... and git hooks", "Every git commit
auto-tags", "Zero-manual versioning with git hooks", "hooks installed
automatically", "auto-tags v1.0.0. Every commit is versioned". Hooks have been
opt-in since v0.4.0. You follow the site, commit, and versioning never fires.
Nothing errors.

**A rendering bug, live right now.** `{{ user_name }}` and `{{ plan }}` were
not wrapped in `{% raw %}`, so Jekyll's Liquid evaluated and erased them:

```
source:    Welcome {{ user_name }}! You're on the {{ plan }} plan.
rendered:  Welcome ! You're on the  plan.
```

The page teaching prompt variables was displaying them blank. Eight more in the
versioning demo. Found by diffing rendered `_site` against source, not by
reading the source.

## Rewritten because v0.6.0 changed the answer

"Semantic Versioning Rules" said MINOR for variables added and MAJOR only for
required variables removed. As of v0.6.0, adding a **required** variable is
MAJOR, so is retyping one or dropping a declared model, and a metadata-only
edit does not bump at all.

The hook and `promptops test diff` now share one grader. Before v0.6.0 they
graded the same edit MINOR and MAJOR respectively, so CI could block a PR as
breaking while the hook stamped a non-breaking version on the same commit.
**Publishing the old table after that release would have told people a breaking
change was safe.**

Three feature cards also replaced with what the product does now (incident
archaeology, semver impact at review, opt-in hooks). The page had no mention of
`blame`, `doctor`, `history`, or the snapshot runtime.

## Verified, not assumed

- All 9 commands on the changed pages **executed** against `llmhq-promptops
  0.6.0` installed from PyPI into a clean venv. That is what caught the bare
  `promptops init`.
- The hook output shown is **byte-exact from a real commit**.
- `jekyll build` exits 0, no errors or warnings, and the **rendered** `_site`
  was checked rather than the source: no stale claim survives, PromptOps shows
  v0.6.0 while ReleaseOps correctly still shows v0.1.0, and no Liquid holes
  remain.

Nothing in ReleaseOps was touched. Its 517 tests pass against PromptOps 0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)